### PR TITLE
fix: include context field in POST /api/tasks INSERT

### DIFF
--- a/packages/backend/src/server.js
+++ b/packages/backend/src/server.js
@@ -372,6 +372,7 @@ fastify.post('/api/tasks', {
       properties: {
         title: { type: 'string', description: 'Task title (required)' },
         description: { type: 'string', description: 'Task description' },
+        context: { type: 'string', description: 'Task context/notes' },
         status: { type: 'string', enum: ['backlog', 'todo', 'in_progress', 'review', 'completed'], default: 'backlog' },
         tags: { type: 'array', items: { type: 'string' }, default: [] },
         agent_id: { type: 'integer', description: 'Assigned agent ID' },
@@ -392,6 +393,7 @@ fastify.post('/api/tasks', {
   const {
     title,
     description,
+    context,
     status = 'backlog',
     tags = [],
     agent_id,
@@ -413,6 +415,7 @@ fastify.post('/api/tasks', {
     `INSERT INTO tasks (
       title,
       description,
+      context,
       status,
       tags,
       agent_id,
@@ -425,12 +428,13 @@ fastify.post('/api/tasks', {
     )
      VALUES (
       ${param(1)}, ${param(2)}, ${param(3)}, ${param(4)}, ${param(5)},
-      ${param(6)}, ${param(7)}, ${param(8)}, ${param(9)}, ${param(10)}, ${param(11)}
+      ${param(6)}, ${param(7)}, ${param(8)}, ${param(9)}, ${param(10)}, ${param(11)}, ${param(12)}
     )
      RETURNING *`,
     [
       title,
       description || null,
+      context || null,
       status,
       tagsValue,
       agent_id || null,


### PR DESCRIPTION
## Problem

The `context` field is silently dropped when creating tasks via `POST /api/tasks`. The API accepts the request without error, but the `context` is `null` when the task is fetched afterward. `PUT` (update) works correctly because it uses `COALESCE` and already handles `context`.

## Root Cause

Three places in the `POST /api/tasks` handler were missing `context`:
1. **Body schema** — `context` was not listed as an allowed property, so Fastify's schema validation may strip it before the handler sees it.
2. **Destructuring** — `context` was not destructured from `request.body`.
3. **SQL INSERT** — `context` was absent from both the column list and the `VALUES` clause.

## Fix

- Added `context: { type: 'string', description: 'Task context/notes' }` to the POST body schema
- Destructured `context` from `request.body`
- Added `context` as column 3 in the `INSERT` (between `description` and `status`), with param index `${param(3)}` and value `context || null`; remaining params shifted up by one accordingly

## Testing

```bash
# Create a task with context
curl -s -X POST https://$CLAW_CONTROL_URL/api/tasks \
  -H 'Content-Type: application/json' \
  -H 'x-api-key: $CLAW_CONTROL_API_KEY' \
  -d '{"title": "Test context fix", "context": "This is my context"}' | jq .context

# Expected: "This is my context"
# Before fix: null
```

Closes #3