### PR TITLE
fix: add API key auth headers to all frontend write operations

### DIFF
--- a/packages/frontend/entrypoint.sh
+++ b/packages/frontend/entrypoint.sh
@@ -15,6 +15,13 @@ elif [ -n "$API_URL" ]; then
   echo "  API_URL: \"$API_URL\"," >> $CONFIG_FILE
 fi
 
+# API Key - required for authenticated write operations (POST/PUT/DELETE)
+if [ -n "$VITE_API_KEY" ]; then
+  echo "  API_KEY: \"$VITE_API_KEY\"," >> $CONFIG_FILE
+elif [ -n "$API_KEY" ]; then
+  echo "  API_KEY: \"$API_KEY\"," >> $CONFIG_FILE
+fi
+
 echo "};" >> $CONFIG_FILE
 
 echo "Generated config.js:"

--- a/packages/frontend/public/config.js
+++ b/packages/frontend/public/config.js
@@ -2,4 +2,5 @@
 // For local development, API calls default to same-origin (empty string)
 window.__CLAW_CONFIG__ = {
   // API_URL: "http://localhost:3001",
+  // API_KEY: "",  // Set via VITE_API_KEY or API_KEY env var at container startup
 };

--- a/packages/frontend/src/hooks/useApi.ts
+++ b/packages/frontend/src/hooks/useApi.ts
@@ -19,10 +19,16 @@ import type { Agent, Task, Message, KanbanData, TaskStatus, Comment, TaskAssigne
  */
 declare global {
   interface Window {
-    __CLAW_CONFIG__?: { API_URL?: string };
+    __CLAW_CONFIG__?: { API_URL?: string; API_KEY?: string };
   }
 }
 const API_BASE = window.__CLAW_CONFIG__?.API_URL || import.meta.env.VITE_API_URL || '';
+const API_KEY = window.__CLAW_CONFIG__?.API_KEY || import.meta.env.VITE_API_KEY || '';
+
+/** Returns auth headers if an API key is configured. */
+function authHeaders(): Record<string, string> {
+  return API_KEY ? { 'x-api-key': API_KEY } : {};
+}
 
 /**
  * Transforms raw API task data to typed Task object.
@@ -171,6 +177,7 @@ export async function createTaskComment(
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        ...authHeaders(),
       },
       body: JSON.stringify(body),
     });
@@ -193,7 +200,7 @@ export async function updateTaskContext(taskId: string, context: string): Promis
   try {
     const res = await fetch(`${API_BASE}/api/tasks/${taskId}`, {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
       body: JSON.stringify({ context }),
     });
     if (!res.ok) return null;
@@ -211,7 +218,7 @@ export async function approveTask(taskId: string, approvedBy: string): Promise<T
   try {
     const res = await fetch(`${API_BASE}/api/tasks/${taskId}/approve`, {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
       body: JSON.stringify({ approved_by: approvedBy }),
     });
     if (!res.ok) return null;
@@ -229,7 +236,7 @@ export async function updateTaskApproval(taskId: string, requiresApproval: boole
   try {
     const res = await fetch(`${API_BASE}/api/tasks/${taskId}`, {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
       body: JSON.stringify({ requires_approval: requiresApproval }),
     });
     if (!res.ok) return null;
@@ -255,7 +262,7 @@ export async function updateTaskDeliverable(
   try {
     const res = await fetch(`${API_BASE}/api/tasks/${taskId}`, {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
       body: JSON.stringify({ deliverable_type: deliverableType, deliverable_content: deliverableContent }),
     });
     if (!res.ok) return null;
@@ -296,7 +303,7 @@ export async function addTaskAssignee(taskId: string, agentId: number, role = 'c
   try {
     const res = await fetch(`${API_BASE}/api/tasks/${taskId}/assignees`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
       body: JSON.stringify({ agent_id: agentId, role }),
     });
     if (!res.ok) return null;
@@ -319,7 +326,7 @@ export async function addTaskAssignee(taskId: string, agentId: number, role = 'c
  */
 export async function removeTaskAssignee(taskId: string, agentId: string): Promise<boolean> {
   try {
-    const res = await fetch(`${API_BASE}/api/tasks/${taskId}/assignees/${agentId}`, { method: 'DELETE' });
+    const res = await fetch(`${API_BASE}/api/tasks/${taskId}/assignees/${agentId}`, { method: 'DELETE', headers: authHeaders() });
     return res.ok;
   } catch {
     return false;
@@ -344,7 +351,7 @@ export async function fetchSubtasks(taskId: string): Promise<Subtask[]> {
 export async function createSubtask(taskId: string, title: string): Promise<Subtask | null> {
   try {
     const res = await fetch(`${API_BASE}/api/tasks/${taskId}/subtasks`, {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      method: 'POST', headers: { 'Content-Type': 'application/json', ...authHeaders() },
       body: JSON.stringify({ title }),
     });
     if (!res.ok) return null;
@@ -358,7 +365,7 @@ export async function createSubtask(taskId: string, title: string): Promise<Subt
 export async function updateSubtask(taskId: string, subtaskId: string, updates: Partial<{ title: string; status: string }>): Promise<Subtask | null> {
   try {
     const res = await fetch(`${API_BASE}/api/tasks/${taskId}/subtasks/${subtaskId}`, {
-      method: 'PUT', headers: { 'Content-Type': 'application/json' },
+      method: 'PUT', headers: { 'Content-Type': 'application/json', ...authHeaders() },
       body: JSON.stringify(updates),
     });
     if (!res.ok) return null;
@@ -371,7 +378,7 @@ export async function updateSubtask(taskId: string, subtaskId: string, updates: 
 
 export async function deleteSubtask(taskId: string, subtaskId: string): Promise<boolean> {
   try {
-    const res = await fetch(`${API_BASE}/api/tasks/${taskId}/subtasks/${subtaskId}`, { method: 'DELETE' });
+    const res = await fetch(`${API_BASE}/api/tasks/${taskId}/subtasks/${subtaskId}`, { method: 'DELETE', headers: authHeaders() });
     return res.ok;
   } catch { return false; }
 }
@@ -527,7 +534,7 @@ export function useTasks() {
     try {
       await fetch(`${API_BASE}/api/tasks/${taskId}`, {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify({ status: newStatus }),
       });
     } catch {


### PR DESCRIPTION
## Problem

Clicking the comment send button in the task detail modal does nothing. No comment appears, no error is shown. The backend endpoint (`POST /api/tasks/:id/comments`) works correctly via curl (with API key).

## Root Cause

The frontend was making all write requests (`POST`/`PUT`/`DELETE`) without including an `x-api-key` authentication header. When the backend is in auth-enabled mode (`API_KEY` env var is set), these requests return `401 Unauthorized`. The frontend code catches this silently:

```ts
if (!res.ok) return null;  // 401 is caught here, returns null
```

`createTaskComment` returns `null`, `handleSubmitComment` checks `if (comment)` (false), and the UI does nothing — no error shown to the user.

The same silent failure affects all other write operations (context saving, subtasks, assignees, task moves, etc.) but comments are the most immediately visible.

## Fix

### `useApi.ts`
- Added `API_KEY` constant (reads from `window.__CLAW_CONFIG__.API_KEY` or `VITE_API_KEY` build-time env var)
- Added `authHeaders()` helper that returns `{ 'x-api-key': API_KEY }` when configured
- Spread `...authHeaders()` into all write fetch calls: `createTaskComment`, `updateTaskContext`, `updateTaskDeliverable`, `approveTask`, `updateTaskApproval`, `addTaskAssignee`, `removeTaskAssignee`, `createSubtask`, `updateSubtask`, `deleteSubtask`, `moveTask`

### `entrypoint.sh`
- Injects `API_KEY` into the runtime `config.js` at container startup from `VITE_API_KEY` or `API_KEY` environment variable

### `public/config.js`
- Documents the new `API_KEY` config option

## Deployment

Set `VITE_API_KEY` (or `API_KEY`) on the **Railway frontend service** to the same value as the backend's `API_KEY`. The entrypoint will inject it into the runtime config served to the browser.

> ⚠️ This exposes the API key to browser clients. Since Claw Control is a private tool, this is acceptable — but consider scoping the API key to write-only operations if you want extra hardening.

## Testing

1. Set matching `API_KEY` on both frontend and backend Railway services  
2. Open a task detail modal  
3. Type a comment and click the send button (or press Enter)  
4. Comment should appear immediately in the list